### PR TITLE
Discord link consistency

### DIFF
--- a/src/i18n/_global.json
+++ b/src/i18n/_global.json
@@ -19,7 +19,7 @@
 	"ODYSSEY_DISCORD_URL": "https://discord.com/users/315843700490240002/",
 	"DEVNOL": "Devnol",
 	"DEVNOL_MATRIX_URL": "https://matrix.to/#/@devnol:projectsegfau.lt/",
-	"DEVNOL_DISCORD_URL": "https://discordapp.com/users/429353559566319626/",
+	"DEVNOL_DISCORD_URL": "https://discord.com/users/429353559566319626/",
 	"MONERO": "Monero",
 	"MINECRAFT_JAVA_IP": "mc.projectsegfau.lt:25565",
 	"MINECRAFT_BEDROCK_IP": "mc.projectsegfau.lt:19132",


### PR DESCRIPTION
Changed Devnol's discord link to an equivalent one, but with the same domain as the other ones. Basically, all links were discord.com ones, but that was a discordapp.com one. It makes no difference at all, as it automatically redirects to the first one, but it was causing me OCD that inconsistency.